### PR TITLE
Use PHP time

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+# A few fixes and additions for a Prestashop add-on
+
 # Cron tasks manager
 
 ## About

--- a/classes/CronJobsForms.php
+++ b/classes/CronJobsForms.php
@@ -305,7 +305,7 @@ class CronJobsForms
             $cron['hour'] = ($cron['hour'] == -1) ? self::$module->l('Every hour', 'CronJobsForms') : date('H:i', mktime((int)$cron['hour'], 0, 0, 0, 1));
             $cron['day'] = ($cron['day'] == -1) ? self::$module->l('Every day', 'CronJobsForms') : (int)$cron['day'];
             $cron['month'] = ($cron['month'] == -1) ? self::$module->l('Every month', 'CronJobsForms') : self::$module->l(date('F', mktime(0, 0, 0, (int)$cron['month'], 1)));
-            $cron['day_of_week'] = ($cron['day_of_week'] == -1) ? self::$module->l('Every day of the week', 'CronJobsForms') : self::$module->l(date('l', mktime(0, 0, 0, 0, (int)$cron['day_of_week'])));
+            $cron['day_of_week'] = ($cron['day_of_week'] == -1) ? self::$module->l('Every day of the week', 'CronJobsForms') : self::$module->l(date('l', strtotime('Sunday + '.(int)$cron['day_of_week'].' days')));
             $cron['updated_at'] = ($cron['updated_at'] == 0) ? self::$module->l('Never', 'CronJobsForms') : date('Y-m-d H:i:s', strtotime($cron['updated_at']));
             $cron['one_shot'] = (bool)$cron['one_shot'];
             $cron['active'] = (bool)$cron['active'];

--- a/controllers/admin/AdminCronJobsController.php
+++ b/controllers/admin/AdminCronJobsController.php
@@ -65,7 +65,9 @@ class AdminCronJobsController extends ModuleAdminController
                     break;
                 } elseif ($this->shouldBeExecuted($cron) == true) {
                     Hook::exec('actionCronJob', array(), $cron['id_module']);
-                    $query = 'UPDATE '._DB_PREFIX_.bqSQL($this->module->name).' SET `updated_at` = NOW(), `active` = IF (`one_shot` = TRUE, FALSE, `active`) WHERE `id_cronjob` = \''.(int)$cron['id_cronjob'].'\'';
+                    $now = date('Y-m-d H:i:s');
+                    $query = 'UPDATE '._DB_PREFIX_.bqSQL($this->module->name).' SET `updated_at` = \''.$now.'\', `active` = IF (`one_shot` = TRUE, FALSE, `active`) WHERE `id_cronjob` = \''.(int)$cron['id_cronjob'].'\'';
+                    //$query = 'UPDATE '._DB_PREFIX_.bqSQL($this->module->name).' SET `updated_at` = NOW(), `active` = IF (`one_shot` = TRUE, FALSE, `active`) WHERE `id_cronjob` = \''.(int)$cron['id_cronjob'].'\'';
                     Db::getInstance()->execute($query);
                 }
             }
@@ -81,7 +83,9 @@ class AdminCronJobsController extends ModuleAdminController
             foreach ($crons as &$cron) {
                 if ($this->shouldBeExecuted($cron) == true) {
                     Tools::file_get_contents(urldecode($cron['task']), false);
-                    $query = 'UPDATE '._DB_PREFIX_.bqSQL($this->module->name).' SET `updated_at` = NOW(), `active` = IF (`one_shot` = TRUE, FALSE, `active`) WHERE `id_cronjob` = \''.(int)$cron['id_cronjob'].'\'';
+                    $now = date('Y-m-d H:i:s');
+                    $query = 'UPDATE '._DB_PREFIX_.bqSQL($this->module->name).' SET `updated_at` = \''.$now.'\', `active` = IF (`one_shot` = TRUE, FALSE, `active`) WHERE `id_cronjob` = \''.(int)$cron['id_cronjob'].'\'';
+                    //$query = 'UPDATE '._DB_PREFIX_.bqSQL($this->module->name).' SET `updated_at` = NOW(), `active` = IF (`one_shot` = TRUE, FALSE, `active`) WHERE `id_cronjob` = \''.(int)$cron['id_cronjob'].'\'';
                     Db::getInstance()->execute($query);
                 }
             }


### PR DESCRIPTION
If MySQL server is using different time zone, logging executed events showed incorrect time. Using PHP date() function instead MySQL NOW() solves the problem